### PR TITLE
Looks like a botched URI for the pyff namespace constant?

### DIFF
--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -12,7 +12,7 @@ NS = {"md": "urn:oasis:names:tc:SAML:2.0:metadata",
       'mdrpi': "urn:oasis:names:tc:SAML:metadata:rpi",
       'shibmd': "urn:mace:shibboleth:metadata:1.0",
       'xrd': 'http://docs.oasis-open.org/ns/xri/xrd-1.0',
-      'pyff': 'http://pyff.iof/NS',
+      'pyff': 'http://pyff.io/NS',
       'xml': 'http://www.w3.org/XML/1998/namespace',
       'saml': "urn:oasis:names:tc:SAML:2.0:assertion"}
 


### PR DESCRIPTION
Not sure for what this xmlns declaration is needed, but I found this broken URI in some generated SAML. FWIW, there wasn't even an XML element using that namespace in the document.