### PR TITLE
XSLT that copies mdrpi:RegistrationInfo/@registrationAuthority to an EA

### DIFF
--- a/src/pyff/xslt/regauth.xsl
+++ b/src/pyff/xslt/regauth.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+  xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+
+  <xsl:param name="entityAttribute" select="'http://aai.dfn.de/edugain/registrationAuthority'"/>
+
+  <xsl:template match="node()|@*" name="identity">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:template match="md:EntityDescriptor/md:Extensions/mdattr:EntityAttributes">
+    <xsl:copy>
+      <xsl:apply-templates select="node()"/>
+        <saml:Attribute Name="{$entityAttribute}" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue><xsl:value-of select="../mdrpi:RegistrationInfo/@registrationAuthority"/></saml:AttributeValue>
+        </saml:Attribute>
+    </xsl:copy>
+    <xsl:apply-templates select="md:EntityDescriptor"/>
+  </xsl:template>
+
+  <xsl:template match="md:EntityDescriptor/md:Extensions[not(mdattr:EntityAttributes)]">
+    <xsl:copy>
+      <xsl:apply-templates select="node()"/>
+      <mdattr:EntityAttributes>
+        <saml:Attribute Name="{$entityAttribute}" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+          <saml:AttributeValue><xsl:value-of select="mdrpi:RegistrationInfo/@registrationAuthority"/></saml:AttributeValue>
+        </saml:Attribute>
+      </mdattr:EntityAttributes>
+    </xsl:copy>
+    <xsl:apply-templates select="md:EntityDescriptor"/>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Copy an existing `registrationAuthority` value into an Entity Attribute (of configurable value) in the same EntityDescriptor, allowing simpler filtering based on registrar by metadata consumers. Makes installation of https://github.com/ukf/mdrpi-match-idp-ext (Shibboleth IDP v2 extension to process `registrationAuthority`) at the metadata consumer unnecessary, at the cost of slightly bloating the EntityDescriptor (redundant information).
Usage:
```yaml
    - xslt:
        stylesheet: regauth.xsl
        #entityAttribute: http://example.org/attributes/registrationAuthority
```
The default is to use the Entity Attribute defined by DFN-AAI to specifically express `registrationAuthority` (`http://aai.dfn.de/edugain/registrationAuthority`) but this can easily be replaced with a value of your own chosing (commented example above).