### PR TITLE
Patch to improve setup.py w.r.t. robustness across platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
 from distutils.core import setup
+from os.path import abspath, dirname, join
+from platform import python_implementation
 from setuptools import find_packages
-import sys, os
+from sys import version_info
 
-here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
-NEWS = open(os.path.join(here, 'NEWS.txt')).read()
+__author__ = 'Leif Johansson'
+__version__ = '0.10.0dev'
 
-version = '0.10.0dev'
+here = abspath(dirname(__file__))
+README = open(join(here, 'README.rst')).read()
+NEWS = open(join(here, 'NEWS.txt')).read()
 
 install_requires = [
     'lxml >=3.0',
@@ -25,15 +30,23 @@ install_requires = [
     'requests'
 ]
 
+python_implementation_str = python_implementation()
+
+if (python_implementation_str == 'CPython' and version_info.major == 2 and (version_info.minor == 6 or version_info.minor == 7)):
+    raise RuntimeError('ERROR: running under unsupported {python_implementation_str:s} version '
+                       '{major_version:d}.{minor_version:d}. Please consult the documentation for supported platforms. '
+                       .format(python_implementation_str=python_implementation_str,
+                               major_version=version_info.major,
+                               minor_version=version_info.minor))
 setup(name='pyFF',
-      version=version,
+      version=__version__,
       description="Federation Feeder",
       long_description=README + '\n\n' + NEWS,
       classifiers=[
           # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       ],
       keywords='identity federation saml metadata',
-      author='Leif Johansson',
+      author=__author__,
       author_email='leifj@sunet.se',
       url='http://blogs.mnt.se',
       license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
 
 python_implementation_str = python_implementation()
 
-if (python_implementation_str == 'CPython' and version_info.major == 2 and (version_info.minor == 6 or version_info.minor == 7)):
+if not (python_implementation_str == 'CPython' and version_info.major == 2 and (version_info.minor == 6 or version_info.minor == 7)):
     raise RuntimeError('ERROR: running under unsupported {python_implementation_str:s} version '
                        '{major_version:d}.{minor_version:d}. Please consult the documentation for supported platforms. '
                        .format(python_implementation_str=python_implementation_str,


### PR DESCRIPTION
I created a Docker container, installing pyFF from PyPI using `pip` into it. pyFF happened to be installed under CPython 3.4. However, pyFF 0.9.4 is syntactically incompatible with CPython 3, and thus the installed `pyff` executable was unusable. Depending on circumstances, it may take some time to rebuild such a container. Furthermore, in this case, installing PyFF 0.9.4 appears to still require a dual Python 2 and Python 3 installation in a container image intended to be minimal in size. The ideal solution is to complete Python 3 support. For now, here is a pull request that improves `setup.py` to ‘fail early’ in case of invocation under an unsupported platform according the documentation.

@leifj, please review for merging.